### PR TITLE
Auto pickup items. Limit map explore to admins. ChainLightning fixed …

### DIFF
--- a/Client/Controls/DXConfigWindow.cs
+++ b/Client/Controls/DXConfigWindow.cs
@@ -31,7 +31,7 @@ namespace Client.Controls
 
         //Game 
         public DXTab GameTab;
-        private DXCheckBox ItemNameCheckBox, MonsterNameCheckBox, PlayerNameCheckBox, UserHealthCheckBox, MonsterHealthCheckBox, DamageNumbersCheckBox, 
+        private DXCheckBox ItemNameCheckBox, AutoPickUpCheckBox, MonsterNameCheckBox, PlayerNameCheckBox, UserHealthCheckBox, MonsterHealthCheckBox, DamageNumbersCheckBox, 
             EscapeCloseAllCheckBox, ShiftOpenChatCheckBox, RightClickDeTargetCheckBox, MonsterBoxVisibleCheckBox, LogChatCheckBox, DrawEffectsCheckBox, 
             DrawParticlesCheckBox, DrawWeatherCheckBox;
         public DXCheckBox DisplayHelmetCheckBox, HideChatBarCheckBox;
@@ -78,6 +78,7 @@ namespace Client.Controls
             PortBox.ValueTextBox.TextBox.Text = Config.Port.ToString();
 
             ItemNameCheckBox.Checked= Config.ShowItemNames;
+            AutoPickUpCheckBox.Checked = Config.AutoPickUpItems;
             MonsterNameCheckBox.Checked = Config.ShowMonsterNames;
             PlayerNameCheckBox.Checked = Config.ShowPlayerNames;
             UserHealthCheckBox.Checked = Config.ShowUserHealth;
@@ -381,54 +382,61 @@ namespace Client.Controls
             };
             ItemNameCheckBox.Location = new Point(120 - ItemNameCheckBox.Size.Width, 10);
 
+            AutoPickUpCheckBox = new DXCheckBox
+            {
+                Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabAutoPickUpItems },
+                Parent = GameTab,
+            };
+            AutoPickUpCheckBox.Location = new Point(120 - AutoPickUpCheckBox.Size.Width, 35);
+
             MonsterNameCheckBox = new DXCheckBox
             {
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabMonsterNameLabel },
                 Parent = GameTab,
             };
-            MonsterNameCheckBox.Location = new Point(120 - MonsterNameCheckBox.Size.Width, 35);
+            MonsterNameCheckBox.Location = new Point(120 - MonsterNameCheckBox.Size.Width, 60);
 
             PlayerNameCheckBox = new DXCheckBox
             {
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabPlayerNameLabel },
                 Parent = GameTab,
             };
-            PlayerNameCheckBox.Location = new Point(120 - PlayerNameCheckBox.Size.Width, 60);
+            PlayerNameCheckBox.Location = new Point(120 - PlayerNameCheckBox.Size.Width, 85);
 
             UserHealthCheckBox = new DXCheckBox
             {
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabUserHealthLabel },
                 Parent = GameTab,
             };
-            UserHealthCheckBox.Location = new Point(120 - UserHealthCheckBox.Size.Width, 85);
+            UserHealthCheckBox.Location = new Point(120 - UserHealthCheckBox.Size.Width, 110);
 
             MonsterHealthCheckBox = new DXCheckBox
             {
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabMonsterHealthLabel },
                 Parent = GameTab,
             };
-            MonsterHealthCheckBox.Location = new Point(120 - MonsterHealthCheckBox.Size.Width, 110);
+            MonsterHealthCheckBox.Location = new Point(120 - MonsterHealthCheckBox.Size.Width, 135);
 
             DamageNumbersCheckBox = new DXCheckBox
             {
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabDamageNumbersLabel },
                 Parent = GameTab,
             };
-            DamageNumbersCheckBox.Location = new Point(120 - DamageNumbersCheckBox.Size.Width, 135);
+            DamageNumbersCheckBox.Location = new Point(120 - DamageNumbersCheckBox.Size.Width, 160);
 
             DrawParticlesCheckBox = new DXCheckBox
             {
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabDrawParticlesLabel },
                 Parent = GameTab,
             };
-            DrawParticlesCheckBox.Location = new Point(120 - DrawParticlesCheckBox.Size.Width, 160);
+            DrawParticlesCheckBox.Location = new Point(120 - DrawParticlesCheckBox.Size.Width, 185);
 
             DisplayHelmetCheckBox = new DXCheckBox
             {
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabDisplayHelmetLabel },
                 Parent = GameTab,
             };
-            DisplayHelmetCheckBox.Location = new Point(120 - DisplayHelmetCheckBox.Size.Width, 185);
+            DisplayHelmetCheckBox.Location = new Point(120 - DisplayHelmetCheckBox.Size.Width, 210);
             DisplayHelmetCheckBox.MouseClick += (o, e) =>
             {
                 CEnvir.Enqueue(new C.HelmetToggle { HideHelmet = DisplayHelmetCheckBox.Checked });
@@ -440,7 +448,7 @@ namespace Client.Controls
                 Parent = GameTab,
                 Hint = "Hide chat bar when not active"
             };
-            HideChatBarCheckBox.Location = new Point(120 - HideChatBarCheckBox.Size.Width, 210);
+            HideChatBarCheckBox.Location = new Point(270 - HideChatBarCheckBox.Size.Width, 10);
             HideChatBarCheckBox.MouseClick += (o, e) =>
             {
                 if (HideChatBarCheckBox.Checked)
@@ -454,7 +462,7 @@ namespace Client.Controls
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabEscapeCloseAllLabel },
                 Parent = GameTab,
             };
-            EscapeCloseAllCheckBox.Location = new Point(270 - EscapeCloseAllCheckBox.Size.Width, 10);
+            EscapeCloseAllCheckBox.Location = new Point(270 - EscapeCloseAllCheckBox.Size.Width, 35);
 
             ShiftOpenChatCheckBox = new DXCheckBox
             {
@@ -462,7 +470,7 @@ namespace Client.Controls
                 Parent = GameTab,
                 Hint = CEnvir.Language.CommonControlConfigWindowGameTabShiftOpenChatHint
             };
-            ShiftOpenChatCheckBox.Location = new Point(270 - ShiftOpenChatCheckBox.Size.Width, 35);
+            ShiftOpenChatCheckBox.Location = new Point(270 - ShiftOpenChatCheckBox.Size.Width, 60);
 
             RightClickDeTargetCheckBox = new DXCheckBox
             {
@@ -470,40 +478,40 @@ namespace Client.Controls
                 Parent = GameTab,
                 Hint = CEnvir.Language.CommonControlConfigWindowGameTabRightClickDeTargetHint
             };
-            RightClickDeTargetCheckBox.Location = new Point(270 - RightClickDeTargetCheckBox.Size.Width, 60);
+            RightClickDeTargetCheckBox.Location = new Point(270 - RightClickDeTargetCheckBox.Size.Width, 85);
 
             MonsterBoxVisibleCheckBox = new DXCheckBox
             {
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabMonsterBoxVisibleLabel },
                 Parent = GameTab,
             };
-            MonsterBoxVisibleCheckBox.Location = new Point(270 - MonsterBoxVisibleCheckBox.Size.Width, 85);
+            MonsterBoxVisibleCheckBox.Location = new Point(270 - MonsterBoxVisibleCheckBox.Size.Width, 110);
 
             LogChatCheckBox = new DXCheckBox
             {
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabLogChatLabel },
                 Parent = GameTab,
             };
-            LogChatCheckBox.Location = new Point(270 - LogChatCheckBox.Size.Width, 110);
+            LogChatCheckBox.Location = new Point(270 - LogChatCheckBox.Size.Width, 135);
 
             DrawEffectsCheckBox = new DXCheckBox
             {
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabDrawEffectsLabel },
                 Parent = GameTab,
             };
-            DrawEffectsCheckBox.Location = new Point(270 - DrawEffectsCheckBox.Size.Width, 135);
+            DrawEffectsCheckBox.Location = new Point(270 - DrawEffectsCheckBox.Size.Width, 160);
 
             DrawWeatherCheckBox = new DXCheckBox
             {
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabDrawWeatherLabel },
                 Parent = GameTab,
             };
-            DrawWeatherCheckBox.Location = new Point(270 - DrawWeatherCheckBox.Size.Width, 160);
+            DrawWeatherCheckBox.Location = new Point(270 - DrawWeatherCheckBox.Size.Width, 185);
 
             KeyBindButton = new DXButton
             {
                 Parent = GameTab,
-                Location = new Point(190, 185),
+                Location = new Point(190, 210),
                 Size = new Size(80, SmallButtonHeight),
                 ButtonType = ButtonType.SmallButton,
                 Label = { Text = CEnvir.Language.CommonControlConfigWindowGameTabKeyBindButtonLabel }

--- a/Client/Envir/CConnection.cs
+++ b/Client/Envir/CConnection.cs
@@ -793,6 +793,10 @@ namespace Client.Envir
 
             MapObject.User.NameChanged();
         }
+        public void Process(S.ChangeMapRegion p)
+        {
+            GameScene.Game.BigMapBox.ChangeRegion();
+        }
         public void Process(S.DayChanged p)
         {
             GameScene.Game.DayTime = p.DayTime;

--- a/Client/Envir/CEnvir.cs
+++ b/Client/Envir/CEnvir.cs
@@ -718,6 +718,11 @@ namespace Client.Envir
                     bind.Key2 = Keys.D0;
                     bind.Shift2 = true;
                     break;
+                case KeyBindAction.ToggleAutoPickupItems:
+                    bind.Category = "Items";
+                    bind.Key1 = Keys.I;
+                    bind.Shift1 = true; //This means press and hold left shift
+                    break;
                 case KeyBindAction.SpellSet01:
                     bind.Category = "Magic";
                     bind.Key1 = Keys.F1;

--- a/Client/Envir/Config.cs
+++ b/Client/Envir/Config.cs
@@ -62,6 +62,7 @@ namespace Client.Envir
         public static bool DrawParticles { get; set; } = false;
         public static bool DrawWeather { get; set; } = true;
         public static bool ShowItemNames { get; set; } = true;
+        public static bool AutoPickUpItems { get; set; } = true;
         public static bool ShowMonsterNames { get; set; } = true;
         public static bool ShowPlayerNames { get; set; } = true;
         public static bool ShowUserHealth { get; set; } = true;

--- a/Client/Envir/Translations/EnglishMessages.cs
+++ b/Client/Envir/Translations/EnglishMessages.cs
@@ -146,6 +146,7 @@ namespace Client.Envir.Translations
         public override string CommonControlConfigWindowSoundTabMonsterVolumeLabel { get; set; } = "Monster Volume:";
         public override string CommonControlConfigWindowSoundTabMagicVolumeLabel { get; set; } = "Magic Volume:";
         public override string CommonControlConfigWindowGameTabItemNameLabel { get; set; } = "Item Names:";
+        public override string CommonControlConfigWindowGameTabAutoPickUpItems { get; set; } = "Auto Pickup Items:";
         public override string CommonControlConfigWindowGameTabMonsterNameLabel { get; set; } = "Monster Names:";
         public override string CommonControlConfigWindowGameTabPlayerNameLabel { get; set; } = "Player Names:";
         public override string CommonControlConfigWindowGameTabUserHealthLabel { get; set; } = "User Health:";

--- a/Client/Envir/Translations/SpanishMessages.cs
+++ b/Client/Envir/Translations/SpanishMessages.cs
@@ -146,6 +146,7 @@ namespace Client.Envir.Translations
         public override string CommonControlConfigWindowSoundTabMonsterVolumeLabel { get; set; } = "Monster Volume:";
         public override string CommonControlConfigWindowSoundTabMagicVolumeLabel { get; set; } = "Magic Volume:";
         public override string CommonControlConfigWindowGameTabItemNameLabel { get; set; } = "Item Names:";
+        public override string CommonControlConfigWindowGameTabAutoPickUpItems { get; set; } = "Auto pickup items:";
         public override string CommonControlConfigWindowGameTabMonsterNameLabel { get; set; } = "Monster Names:";
         public override string CommonControlConfigWindowGameTabPlayerNameLabel { get; set; } = "Player Names:";
         public override string CommonControlConfigWindowGameTabUserHealthLabel { get; set; } = "User Health:";

--- a/Client/Envir/Translations/StringMessages.cs
+++ b/Client/Envir/Translations/StringMessages.cs
@@ -145,6 +145,7 @@ namespace Client.Envir.Translations
         public abstract string CommonControlConfigWindowSoundTabMonsterVolumeLabel { get; set; }
         public abstract string CommonControlConfigWindowSoundTabMagicVolumeLabel { get; set; }
         public abstract string CommonControlConfigWindowGameTabItemNameLabel { get; set; }
+        public abstract string CommonControlConfigWindowGameTabAutoPickUpItems { get; set; }
         public abstract string CommonControlConfigWindowGameTabMonsterNameLabel { get; set; }
         public abstract string CommonControlConfigWindowGameTabPlayerNameLabel { get; set; }
         public abstract string CommonControlConfigWindowGameTabUserHealthLabel { get; set; }

--- a/Client/Models/UserObject.cs
+++ b/Client/Models/UserObject.cs
@@ -716,6 +716,21 @@ namespace Client.Models
                 if (buff.Pause || buff.RemainingTime == TimeSpan.MaxValue) continue;
                 buff.RemainingTime = Functions.Max(TimeSpan.Zero, buff.RemainingTime - ticks);
             }
+
+            // Auto PickUp Items
+            if (Config.AutoPickUpItems)
+            {
+                if (CEnvir.Now <= GameScene.Game.PickUpTime) return;
+
+                ItemObject item = (ItemObject)CurrentCell.Objects.FirstOrDefault(x => x.Race == ObjectType.Item);
+
+                if (item != null)
+                {
+                    CEnvir.Enqueue(new C.AutoPickUp());
+
+                    GameScene.Game.PickUpTime = CEnvir.Now.AddMilliseconds(500);
+                }
+            }
         }
 
         public override void FrameIndexChanged()

--- a/Client/Scenes/GameScene.cs
+++ b/Client/Scenes/GameScene.cs
@@ -1530,6 +1530,9 @@ namespace Client.Scenes
                     case KeyBindAction.ShowHideItemsName:
                         Config.ShowItemNames = !Config.ShowItemNames;
                         break;
+                    case KeyBindAction.ToggleAutoPickupItems:
+                        Config.AutoPickUpItems = !Config.AutoPickUpItems;
+                        break;
                     default:
                         continue;
                 }

--- a/Client/Scenes/Views/BigMapDialog.cs
+++ b/Client/Scenes/Views/BigMapDialog.cs
@@ -91,6 +91,8 @@ namespace Client.Scenes.Views
 
         public Dictionary<object, DXControl> MapInfoObjects = new Dictionary<object, DXControl>();
 
+        private MapInfo NextRegion;
+
         public override void OnClientAreaChanged(Rectangle oValue, Rectangle nValue)
         {
             base.OnClientAreaChanged(oValue, nValue);
@@ -303,9 +305,19 @@ namespace Client.Scenes.Views
                     control.LibraryFile = LibraryFile.GameInter;
                     break;
             }
-            control.MouseClick += (o, e) => SelectedInfo = ob.DestinationRegion.Map;
+            control.MouseClick += (o, e) => { 
+                NextRegion = ob.DestinationRegion.Map; 
+                CEnvir.Enqueue(new C.ChangeMapRegion {}); 
+            };//SelectedInfo = ob.DestinationRegion.Map;
+
             control.Location = new Point((int) (ScaleX*x) - control.Size.Width/2, (int) (ScaleY*y) - control.Size.Height/2);
         }
+
+        public void ChangeRegion()
+        {
+            SelectedInfo = NextRegion;
+        }
+
         public void Update(ClientObjectData ob)
         {
             if (SelectedInfo == null) return;

--- a/Client/UserModels/KeyBindInfo.cs
+++ b/Client/UserModels/KeyBindInfo.cs
@@ -342,5 +342,8 @@ namespace Client.UserModels
 
         [Description("Show/Hide Items Name")]
         ShowHideItemsName,
+
+        [Description("Toggle Auto Pickup Items")]
+        ToggleAutoPickupItems,
     }
 }

--- a/LibraryCore/Network/ClientPackets.cs
+++ b/LibraryCore/Network/ClientPackets.cs
@@ -204,6 +204,7 @@ namespace Library.Network.ClientPackets
 
     public sealed class PickUp : Packet {}
 
+    public sealed class AutoPickUp : Packet { }
     public sealed class Chat : Packet
     {
         public string Text { get; set; }
@@ -654,6 +655,11 @@ namespace Library.Network.ClientPackets
     {
         public Point Location { get; set; }
         public int Index { get; set; }
+    }
+
+    public sealed class ChangeMapRegion : Packet
+    {
+
     }
 
     public sealed class JoinStarterGuild : Packet

--- a/LibraryCore/Network/ServerPackets.cs
+++ b/LibraryCore/Network/ServerPackets.cs
@@ -90,6 +90,10 @@ namespace Library.Network.ServerPackets
         public MirDirection Direction { get; set; }
         public Point Location { get; set; }
     }
+    public sealed class ChangeMapRegion : Packet
+    {
+
+    }
     public sealed class ObjectRemove : Packet
     {
         public uint ObjectID { get; set; }

--- a/ServerLibrary/Envir/SConnection.cs
+++ b/ServerLibrary/Envir/SConnection.cs
@@ -490,6 +490,12 @@ namespace Server.Envir
 
             Player.PickUp();
         }
+        public void Process(C.AutoPickUp p)
+        {
+            if (Stage != GameStage.Game) return;
+
+            Player.AutoPickUpItem();
+        }
         public void Process(C.CurrencyDrop p)
         {
             if (Stage != GameStage.Game) return;
@@ -1286,6 +1292,11 @@ namespace Server.Envir
             if (Stage != GameStage.Game) return;
 
             Player.TeleportRing(p.Location, p.Index);
+        }
+
+        public void Process(C.ChangeMapRegion p)
+        {
+            Player.ChangeMapRegion();
         }
 
         public void Process(C.JoinStarterGuild p)

--- a/ServerLibrary/Models/Magics/Taoist/SummonDemonicCreature.cs
+++ b/ServerLibrary/Models/Magics/Taoist/SummonDemonicCreature.cs
@@ -52,7 +52,7 @@ namespace Server.Models.Magics
 
             if (ob != null)
             {
-                ob.PetRecall();
+                ob.PetRecall(1);
                 return;
             }
 

--- a/ServerLibrary/Models/Magics/Taoist/SummonJinSkeleton.cs
+++ b/ServerLibrary/Models/Magics/Taoist/SummonJinSkeleton.cs
@@ -52,7 +52,7 @@ namespace Server.Models.Magics
 
             if (ob != null)
             {
-                ob.PetRecall();
+                ob.PetRecall(1);
                 return;
             }
 

--- a/ServerLibrary/Models/Magics/Taoist/SummonShinsu.cs
+++ b/ServerLibrary/Models/Magics/Taoist/SummonShinsu.cs
@@ -52,7 +52,7 @@ namespace Server.Models.Magics
 
             if (ob != null)
             {
-                ob.PetRecall();
+                ob.PetRecall(1);
                 return;
             }
 

--- a/ServerLibrary/Models/Magics/Wizard/ChainLightning.cs
+++ b/ServerLibrary/Models/Magics/Wizard/ChainLightning.cs
@@ -71,7 +71,7 @@ namespace Server.Models.Magics
 
                         foreach (var ob in cell.Objects)
                         {
-                            if (ob.Race != ObjectType.Monster || !Player.CanAttackTarget(ob) || !Functions.InRange(CurrentLocation, ob.CurrentLocation, Globals.MagicRange))
+                            if ((ob.Race != ObjectType.Monster && ob.Race != ObjectType.Player) || !Player.CanAttackTarget(ob) || !Functions.InRange(CurrentLocation, ob.CurrentLocation, Globals.MagicRange))
                                 continue;
 
                             if (SEnvir.Random.Next(powerDivisor) == 0)
@@ -108,7 +108,7 @@ namespace Server.Models.Magics
 
                 foreach (var ob in cell.Objects)
                 {
-                    if (ob.Race != ObjectType.Monster || !Player.CanAttackTarget(ob) || !Functions.InRange(CurrentLocation, ob.CurrentLocation, Globals.MagicRange))
+                    if ((ob.Race != ObjectType.Monster && ob.Race != ObjectType.Player) || !Player.CanAttackTarget(ob) || !Functions.InRange(CurrentLocation, ob.CurrentLocation, Globals.MagicRange))
                         continue;
 
                     actualTargets.Add(ob);

--- a/ServerLibrary/Models/MonsterObject.cs
+++ b/ServerLibrary/Models/MonsterObject.cs
@@ -1037,9 +1037,9 @@ namespace Server.Models
 
             Broadcast(new S.ObjectPetOwnerChanged { ObjectID = ObjectID });
         }
-        public void PetRecall()
+        public void PetRecall(int distance = -1)
         {
-            Cell cell = PetOwner.CurrentMap.GetCell(Functions.Move(PetOwner.CurrentLocation, PetOwner.Direction, -1));
+            Cell cell = PetOwner.CurrentMap.GetCell(Functions.Move(PetOwner.CurrentLocation, PetOwner.Direction, distance));
 
             if (cell == null || cell.Movements != null)
                 cell = PetOwner.CurrentCell;

--- a/ServerLibrary/Models/PlayerObject.cs
+++ b/ServerLibrary/Models/PlayerObject.cs
@@ -2617,6 +2617,12 @@ namespace Server.Models
             TeleportTime = SEnvir.Now.AddMinutes(5);
         }
 
+        public void ChangeMapRegion()
+        {
+            if (Character.Account.Admin)
+                Enqueue(new S.ChangeMapRegion { });
+        }
+
         public override void Dodged()
         {
             base.Dodged();
@@ -7654,6 +7660,14 @@ namespace Server.Models
                     }
                 }
             }
+        }
+
+        public void AutoPickUpItem()
+        {
+            ItemObject item = (ItemObject)CurrentCell.Objects.FirstOrDefault(x => x.Race == ObjectType.Item);
+
+            if (item != null)
+                item.PickUpItem(this);
         }
 
         public bool CanWearItem(UserItem item, EquipmentSlot slot)


### PR DESCRIPTION
- Auto pickup items: Now the player can take items automatically when step on them, added option to toggle on/off.
- Limit map explore to admins: Now only admin users can explore through maps from map dialog.
- ChainLightning fixed to affect players.
- When Taoists summon a pet already summoned, it spawns in front of they.